### PR TITLE
Restore deck modal prop translations

### DIFF
--- a/frontend/public/locales/en.json
+++ b/frontend/public/locales/en.json
@@ -20,5 +20,7 @@
   "settings_saved": "Settings saved successfully",
   "settings_save_error": "Error saving settings!",
   "create_first_deck": "Create your first deck",
-  "new_deck": "New Deck"
+  "new_deck": "New Deck",
+  "deck_title": "Deck title",
+  "deck_description": "Deck description"
 }

--- a/frontend/public/locales/tr.json
+++ b/frontend/public/locales/tr.json
@@ -20,5 +20,7 @@
   "settings_saved": "Ayarlar başarıyla kaydedildi",
   "settings_save_error": "Ayarlar kaydedilirken hata oluştu!",
   "create_first_deck": "İlk destenizi oluşturun",
-  "new_deck": "Yeni Deste"
+  "new_deck": "Yeni Deste",
+  "deck_title": "Deste başlığı",
+  "deck_description": "Deste açıklaması"
 }


### PR DESCRIPTION
## Summary
- restore DeckModal to receive the `t` helper via props instead of using the translation context
- update Info to pass the translation helper back into DeckModal

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68eeb0c4a2748327b8486f0d1f16e633