### PR TITLE
feat: db health check

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -52,23 +52,15 @@ app.use("/achievements", achievementsRouter);
 app.use("/admin", adminRouter);
 app.use("/subscriptions", subscriptionsRouter);
 
-app.get("/api", async (req, res) => {
-	const result = await pool.query("SELECT NOW()");
-	res.json({ time: result.rows[0].now });
+app.get("/health", async (req, res) => {
+	res.status(200).json({
+		ok: true,
+		service: "backend",
+		uptimeSec: Math.floor(process.uptime()),
+		timestamp: new Date().toISOString(),
+	});
 });
 
 app.listen(port, () => {
 	console.log(`Backend listening at port: ${port}`);
-});
-
-// Cron job to clean expired refresh tokens daily at 3 AM
-cron.schedule("0 3 * * *", async () => {
-	try {
-		const result = await pool.query(
-			"DELETE FROM refresh_token WHERE expires_at < NOW()",
-		);
-		console.log(`[Cron] Cleaned ${result.rowCount} expired refresh tokens`);
-	} catch (err) {
-		console.error("[Cron] Error cleaning expired refresh tokens:", err);
-	}
 });


### PR DESCRIPTION
This pull request updates the backend server's endpoints and background job handling. The main changes include replacing the old API status endpoint with a more comprehensive health check and removing the daily cron job for cleaning expired refresh tokens.

**Endpoint changes:**

* Replaced the `/api` endpoint, which previously returned the current time from the database, with a new `/health` endpoint that returns service status, uptime, and a timestamp for better health monitoring.

**Background job changes:**

* Removed the scheduled cron job that deleted expired refresh tokens daily at 3 AM, so expired tokens are no longer automatically cleaned up by the backend.