### PR TITLE
fix: shuffle cards

### DIFF
--- a/backend/routes/game.js
+++ b/backend/routes/game.js
@@ -154,7 +154,8 @@ module.exports = (pool) => {
 				"SELECT * FROM flashcard WHERE deck_id = $1 AND enabled = TRUE ORDER BY id ASC",
 				[deckId],
 			);
-			res.json({ flashcards: result.rows });
+			const shuffledFlashcards = shuffleArray(result.rows);
+			res.json({ flashcards: shuffledFlashcards });
 		} catch (err) {
 			console.error("Error:", err);
 			res.status(500).json({ error: "Failed to fetch deck data" });
@@ -210,7 +211,8 @@ module.exports = (pool) => {
 				 ORDER BY (correct_count::float / (correct_count + wrong_count)::float) ASC`,
 				[deckId],
 			);
-			res.json({ flashcards: result.rows });
+			const shuffledFlashcards = shuffleArray(result.rows);
+			res.json({ flashcards: shuffledFlashcards });
 		} catch (err) {
 			console.error("Error fetching hard cards:", err);
 			res.status(500).json({ error: "Failed to fetch hard cards" });
@@ -262,7 +264,7 @@ module.exports = (pool) => {
 				"SELECT * FROM flashcard WHERE deck_id = $1 AND enabled = TRUE ORDER BY id ASC",
 				[deckId],
 			);
-			const flashcards = result.rows;
+			const flashcards = shuffleArray(result.rows);
 
 			const correctField = direction === "reverse" ? "front_text" : "back_text";
 

--- a/frontend/src/pages/Game.jsx
+++ b/frontend/src/pages/Game.jsx
@@ -155,21 +155,20 @@ export default function Game({ onBackToDecks }) {
 
 			if (res.data && Array.isArray(res.data.flashcards)) {
 				let cards = [...res.data.flashcards];
-				const shuffledCards = [...cards].sort(() => Math.random() - 0.5);
 
 				if (gameMode === "match") {
 					cards =
 						selectedCardCount === Number.POSITIVE_INFINITY
 							? cards
-							: shuffledCards.slice(
+							: cards.slice(
 									0,
 									Math.min(selectedCardCount, cards.length),
 								);
 				} else {
 					cards =
 						selectedCardCount === Number.POSITIVE_INFINITY
-							? shuffledCards
-							: shuffledCards.slice(
+							? cards
+							: cards.slice(
 									0,
 									Math.min(selectedCardCount, cards.length),
 								);


### PR DESCRIPTION
This pull request updates the way flashcards are returned from the backend, ensuring that flashcards are shuffled before being sent to the client in various endpoints. This helps provide a randomized experience for users when practicing or reviewing flashcards.

Flashcard shuffling improvements:

* All relevant endpoints in `backend/routes/game.js` now shuffle the array of flashcards before returning them to the client, instead of sending them in a fixed order. This affects both general deck fetching and fetching of "hard" cards. [[1]](diffhunk://#diff-92c8f22cd489ddb1909c5571cf3b8dd6e4b5183e5fcf14a96e4048c3e90276c1L157-R158) [[2]](diffhunk://#diff-92c8f22cd489ddb1909c5571cf3b8dd6e4b5183e5fcf14a96e4048c3e90276c1L213-R215) [[3]](diffhunk://#diff-92c8f22cd489ddb1909c5571cf3b8dd6e4b5183e5fcf14a96e4048c3e90276c1L265-R267)